### PR TITLE
fix: error of segmented data in responses

### DIFF
--- a/Sources/Core/Private/Streaming/DataFetcher.swift
+++ b/Sources/Core/Private/Streaming/DataFetcher.swift
@@ -18,6 +18,13 @@ final class DataFetcher {
         _fullfillMetaDataIfNeeded()
     }
 
+    deinit {
+        if !loadingRequest.isFinished {
+            let error = ZonPlayer.Error.cacheFailed(.streamingRequestCancelled(requester.url))
+            loadingRequest.finishLoading(with: error)
+        }
+    }
+
     func fetch() {
         guard let dataRequest = loadingRequest.theDataRequest else { return }
         var offset = Int(dataRequest.requestedOffset)
@@ -36,14 +43,6 @@ final class DataFetcher {
             }
         } else {
             _checkSource(for: NSRange(location: offset, length: length))
-        }
-    }
-
-    func finishWithCancellation() {
-        if !loadingRequest.isFinished {
-            // Important: make request finish loading but keep downloading.
-            let error = ZonPlayer.Error.cacheFailed(.streamingRequestCancelled(requester.url))
-            loadingRequest.finishLoading(with: error)
         }
     }
 

--- a/Sources/Core/Private/Streaming/DataProvider.swift
+++ b/Sources/Core/Private/Streaming/DataProvider.swift
@@ -27,7 +27,7 @@ final class DataProvider: ZPCStreamingDataProvidable {
     }
 
     func removeLoadingRequest(_ loadingRequest: ZPCLoadingRequestable) {
-        _pendingFetchers.first { $0.loadingRequest == loadingRequest }?.finishWithCancellation()
+        _pendingFetchers.removeAll { $0.loadingRequest == loadingRequest }
     }
 
     private var _pendingFetchers: [DataFetcher] = []

--- a/Sources/Usage/Cache/Streaming/ZPC+DefaultStreamingSource.swift
+++ b/Sources/Usage/Cache/Streaming/ZPC+DefaultStreamingSource.swift
@@ -105,9 +105,6 @@ ZonPlayer Streaming Cache <<< \(url.unsafelyUnwrapped)
 extension ZPC.DefaultStreamingSource {
     private struct _SaveToDiskPlugin: ZPCStreamingPluggable {
         let storage: ZPCDataStorable
-        init(storage: ZPCDataStorable) {
-            self.storage = storage
-        }
 
         func didReceive(
             _ data: Data,


### PR DESCRIPTION
Unexpected runtime behavior:
1. Strange artifacts or corruption for video display in poor network condition.
2. Cache files be damaged potentially.